### PR TITLE
Updates copyright notice at the top of profiles.proto

### DIFF
--- a/opentelemetry/proto/profiles/v1/profiles.proto
+++ b/opentelemetry/proto/profiles/v1/profiles.proto
@@ -1,4 +1,5 @@
 // Copyright 2023, OpenTelemetry Authors
+// Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -224,6 +225,8 @@ enum SymbolFidelity {
   SYMBOL_FIDELITY_UNSPECIFIED = 0;
   SYMBOL_FIDELITY_FULL = 1;
 }
+
+// The following messages were forked from the pprof proto definition and modified to fit the OTLP profile schema:
 
 // Describes the mapping from a binary to its original source code. These are stored in a lookup table in a Profile. These are referenced by index from other messages.
 message Mapping {


### PR DESCRIPTION
As pointed out by @rsc in a recent [OTEP PR](https://github.com/open-telemetry/oteps/pull/237#issuecomment-1714381172) we don't officially provide attribution, even though the proto is obviously based on pprof format.

This PR addresses that by adding an official copyright notice as well as a comment about where some of the message definitions came from.

CC @tigrannajaryan @jsuereth — would love a review from one of you.